### PR TITLE
Allow at most one draft identifier per version, but possibly more than one version per bibitem

### DIFF
--- a/grammars/biblio.rnc
+++ b/grammars/biblio.rnc
@@ -258,7 +258,7 @@ BibliographicItem =
     fetched?,
     formattedref?,
     btitle+, bsource*, docidentifier*, docnumber?, bdate*, contributor*,
-    edition?, version?, biblionote*, language*, script*,
+    edition?, version*, biblionote*, language*, script*,
     bibabstract*, status?, copyright*, docrelation*, series*, medium?, bplace*, bprice*,
     extent*, bibliographic_size?, accesslocation*, license*, bclassification*, bkeyword*, validity?
 
@@ -467,7 +467,7 @@ docrelation =
 
 version =
   element version {
-    revision-date?, draft*
+    revision-date?, draft?
 }
 
 vedition = element edition { xsd:int }

--- a/models/BibliographicItem.lutaml
+++ b/models/BibliographicItem.lutaml
@@ -55,9 +55,9 @@ class BibliographicItem {
       The edition of the bibliographic item.
     }
   }
-  +version: VersionInfo[0..1] {
+  +version: VersionInfo[0..*] {
     definition {
-      The version of the bibliographic item (within an edition). Can be used for drafts.
+      The version of the bibliographic item (within an edition). Can be used for drafts. Can be more than one, in case of multiple versioning schemes.
     }
   }
   +note: TypedNote[0..*] {


### PR DESCRIPTION
#39

Some background:

Per https://github.com/ietf-ribose/relaton-data-ids/issues/9, we started to specify `bibitem.version.draft` to differentiate draft versions from each other, which is good.

However, per LutaML the `draft` property is supposed to contain at most one string, while RNC allowed multiple strings.

To comply with LutaML model and because it’s unclear how `version.draft` can be a list, this declares `version.draft` at most one string in RNC grammar. To support multiple versioning schemes, however, `bibtem.version` is now an array and can contain multiple items, and this is changed in both LutaML and RNC.